### PR TITLE
fix: add icon.png and default images to asset precompilation

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,3 +5,6 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+Rails.application.config.assets.precompile += %w( icon.png icon.svg default-poster.jpg default-event.jpg default-avatar.jpg )


### PR DESCRIPTION
- Add icon.png, icon.svg to precompile list
- Add default images (poster, event, avatar) to precompile
- Fixes 'icon.png not found in load path' error in production
- Ensures favicons and PWA icons are available